### PR TITLE
fix(api): drop Vary:* so resized images are CDN-cacheable

### DIFF
--- a/packages/api/src/controllers/image.controller.ts
+++ b/packages/api/src/controllers/image.controller.ts
@@ -41,6 +41,14 @@ const uploadBodySchema = t.Object({
 
 export const imageController = new Elysia({ prefix: "/images" })
   // .use(AuthMiddleware.apiKeyAuth)
+  // The cors() plugin sets `Vary: *` for wildcard origins, which makes every
+  // response uncacheable (Cloudflare/CDNs refuse to cache `Vary: *`). Resized
+  // images are deterministic per URL+query, so override it with the only header
+  // they actually vary on. Lowercase `vary` overwrites the cors-set value
+  // instead of appending a second header.
+  .onAfterHandle(({ set }) => {
+    set.headers.vary = "Accept-Encoding";
+  })
   .get("/health", () => ({ status: "ok" }))
   .get(
     "/resize/*",


### PR DESCRIPTION
## Problem

`resize-it.airsoftmarket.fr` images never cache at Cloudflare — `cf-cache-status` is `DYNAMIC`/`BYPASS` on every hit, despite the handler sending `Cache-Control: public, max-age=…`. Even a Cloudflare Cache Rule with an explicit Edge-TTL override can't fix it.

## Cause

`.use(cors())` (index.ts) → `@elysiajs/cors@1.2` with default wildcard origin hard-sets **`Vary: *`** (dist L50/L55). Per HTTP spec `Vary: *` = uncacheable, so Cloudflare refuses to cache it regardless of `Cache-Control`.

## Fix

Override `Vary` on image responses to `Accept-Encoding` (the only header resized images actually vary on — deterministic per URL+query). Scoped to the image controller via `onAfterHandle`, lowercase `vary` key so it **replaces** the cors value rather than appending. CORS/ACAO untouched.

## Verify after deploy

```bash
U="https://resize-it.airsoftmarket.fr/images/resize/q6xe2b1zlrdpu1u/1780856429074-jpg?quality=95&width=420&height=420"
curl -sI "$U" | grep -iE 'vary|cf-cache-status'  # vary: Accept-Encoding; 2nd hit → HIT
```

The Cloudflare Cache Rule (host `resize-it.airsoftmarket.fr`, edge-TTL override) is already live; it'll return `HIT` once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)