### PR TITLE
fix(api): drop Vary:* so resized images are CDN-cacheable

### DIFF
--- a/packages/api/src/controllers/image.controller.ts
+++ b/packages/api/src/controllers/image.controller.ts
@@ -41,6 +41,14 @@ const uploadBodySchema = t.Object({
 
 export const imageController = new Elysia({ prefix: "/images" })
   // .use(AuthMiddleware.apiKeyAuth)
+  // The cors() plugin sets `Vary: *` for wildcard origins, which makes every
+  // response uncacheable (Cloudflare/CDNs refuse to cache `Vary: *`). Resized
+  // images are deterministic per URL+query, so override it with the only header
+  // they actually vary on. Lowercase `vary` overwrites the cors-set value
+  // instead of appending a second header.
+  .onAfterHandle(({ set }) => {
+    set.headers.vary = "Accept-Encoding";
+  })
   .get("/health", () => ({ status: "ok" }))
   .get(
     "/resize/*",


### PR DESCRIPTION
Same fix as #5, targeting `master` so it doesn't regress when master is the deploy source.

## Problem
`@elysiajs/cors` (`.use(cors())`, default wildcard origin) hard-sets **`Vary: *`**, which makes every response uncacheable — Cloudflare returns `BYPASS` no matter the `Cache-Control` or an edge-TTL override.

## Fix
Override `Vary` → `Accept-Encoding` on the image controller via `onAfterHandle` (lowercase `vary` key replaces rather than appends). CORS/ACAO behavior untouched. Resized images are deterministic per URL+query, so `Accept-Encoding` is the only header they actually vary on.

## Verify after deploy
```bash
U="https://resize-it.airsoftmarket.fr/images/resize/q6xe2b1zlrdpu1u/1780856429074-jpg?quality=95&width=420&height=420"
curl -sI "$U" | grep -iE 'vary|cf-cache-status'   # vary: Accept-Encoding; 2nd hit → HIT
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)